### PR TITLE
NethServer.repo: make sure 'enabled' option is always defined

### DIFF
--- a/root/etc/e-smith/templates/etc/yum.repos.d/NethServer.repo/10base
+++ b/root/etc/e-smith/templates/etc/yum.repos.d/NethServer.repo/10base
@@ -39,7 +39,7 @@ mirrorlist=http://mirrorlist.nethserver.org/?release=$releasever&repo=ce-base&ar
 gpgcheck=1
 repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
-enabled = {$communityEnabled}
+enabled={$communityEnabled}
 
 [ce-updates]
 name=CE-Updates-$nsrelease
@@ -48,7 +48,7 @@ mirrorlist=http://mirrorlist.nethserver.org/?release=$releasever&repo=ce-updates
 gpgcheck=1
 repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
-enabled = {$communityEnabled}
+enabled={$communityEnabled}
 
 [ce-extras]
 name=CE-Extras-$nsrelease
@@ -57,7 +57,7 @@ mirrorlist=http://mirrorlist.nethserver.org/?release=$releasever&repo=ce-extras&
 gpgcheck=1
 repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
-enabled = {$communityEnabled}
+enabled={$communityEnabled}
 
 [ce-sclo-sclo]
 name=CE-SCLo-sclo-$nsrelease
@@ -66,7 +66,7 @@ mirrorlist=http://mirrorlist.nethserver.org/?release=$releasever&repo=ce-sclo-sc
 gpgcheck=1
 repo_gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
-enabled = {$communityEnabled}
+enabled={$communityEnabled}
 
 [ce-sclo-rh]
 name=CE-SCLo-rh-$nsrelease
@@ -75,4 +75,4 @@ mirrorlist=http://mirrorlist.nethserver.org/?release=$releasever&repo=ce-sclo-rh
 gpgcheck=1
 repo_gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
-enabled = {$communityEnabled}
+enabled={$communityEnabled}

--- a/root/etc/e-smith/templates/etc/yum.repos.d/NethServer.repo/10base
+++ b/root/etc/e-smith/templates/etc/yum.repos.d/NethServer.repo/10base
@@ -1,5 +1,5 @@
 {
-    our $communityEnabled = ! defined $subscription || ! $subscription{'SystemId'};
+    our $communityEnabled = $subscription{'SystemId'} ? '0' : '1';
     '';
 }
 [nethserver-base]

--- a/root/etc/yum.repos.d/NethServer.repo
+++ b/root/etc/yum.repos.d/NethServer.repo
@@ -39,7 +39,7 @@ mirrorlist=http://mirrorlist.nethserver.org/?release=$releasever&repo=ce-base&ar
 gpgcheck=1
 repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
-enabled = 0
+enabled=0
 
 [ce-updates]
 name=CE-Updates-$nsrelease
@@ -48,7 +48,7 @@ mirrorlist=http://mirrorlist.nethserver.org/?release=$releasever&repo=ce-updates
 gpgcheck=1
 repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
-enabled = 0
+enabled=0
 
 [ce-extras]
 name=CE-Extras-$nsrelease
@@ -57,7 +57,7 @@ mirrorlist=http://mirrorlist.nethserver.org/?release=$releasever&repo=ce-extras&
 gpgcheck=1
 repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
-enabled = 0
+enabled=0
 
 [ce-sclo-sclo]
 name=CE-SCLo-sclo-$nsrelease
@@ -66,7 +66,7 @@ mirrorlist=http://mirrorlist.nethserver.org/?release=$releasever&repo=ce-sclo-sc
 gpgcheck=1
 repo_gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
-enabled = 0
+enabled=0
 
 [ce-sclo-rh]
 name=CE-SCLo-rh-$nsrelease
@@ -75,4 +75,4 @@ mirrorlist=http://mirrorlist.nethserver.org/?release=$releasever&repo=ce-sclo-rh
 gpgcheck=1
 repo_gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
-enabled = 0
+enabled=0


### PR DESCRIPTION
On a Enterprise machine the error on `yum repolist` was:
```
Repository 'nethserver-base': Error parsing config: Error parsing "enabled = ''": invalid boolean value
Repository 'nethserver-updates': Error parsing config: Error parsing "enabled = ''": invalid boolean value
Repository 'ce-base': Error parsing config: Error parsing "enabled = ''": invalid boolean value
Repository 'ce-updates': Error parsing config: Error parsing "enabled = ''": invalid boolean value
Repository 'ce-extras': Error parsing config: Error parsing "enabled = ''": invalid boolean value
Repository 'ce-sclo-sclo': Error parsing config: Error parsing "enabled = ''": invalid boolean value
Repository 'ce-sclo-rh': Error parsing config: Error parsing "enabled = ''": invalid boolean value
```

NethServer/dev#5704