### PR TITLE
Add extra Armhfp and aarch64 gpgkeys

### DIFF
--- a/root/etc/e-smith/templates/etc/yum.repos.d/NethServer.repo/10base
+++ b/root/etc/e-smith/templates/etc/yum.repos.d/NethServer.repo/10base
@@ -3,7 +3,7 @@
     our $repo_gpgcheck = '1';
     our $armhfp_gpgkey = "";
     our $aarch64_gpgkey = "";
-        if ( -e '/etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-Arm32' ) {
+    if ( -e '/etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-Arm32' ) {
        $armhfp_gpgkey =  "\n       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-Arm32";
        $repo_gpgcheck = '0';
     }

--- a/root/etc/e-smith/templates/etc/yum.repos.d/NethServer.repo/10base
+++ b/root/etc/e-smith/templates/etc/yum.repos.d/NethServer.repo/10base
@@ -41,7 +41,6 @@ name=CE-Base-$nsrelease
 mirrorlist=http://mirrorlist.nethserver.org/?release=$releasever&repo=ce-base&arch=$basearch&nsrelease=$nsrelease
 #baseurl=http://mirror.centos.org/centos/$nsrelease/os/$basearch/
 gpgcheck=1
-repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 {$armhfp_gpgkey} {$aarch64_gpgkey}
 enabled={$communityEnabled}
 
@@ -50,7 +49,6 @@ name=CE-Updates-$nsrelease
 mirrorlist=http://mirrorlist.nethserver.org/?release=$releasever&repo=ce-updates&arch=$basearch&nsrelease=$nsrelease
 #baseurl=http://mirror.centos.org/centos/$nsrelease/updates/$basearch/
 gpgcheck=1
-repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 {$armhfp_gpgkey} {$aarch64_gpgkey}
 enabled={$communityEnabled}
 
@@ -59,7 +57,6 @@ name=CE-Extras-$nsrelease
 mirrorlist=http://mirrorlist.nethserver.org/?release=$releasever&repo=ce-extras&arch=$basearch&nsrelease=$nsrelease
 #baseurl=http://mirror.centos.org/centos/$nsrelease/extras/$basearch/
 gpgcheck=1
-repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 {$armhfp_gpgkey} {$aarch64_gpgkey}
 enabled={$communityEnabled}
 

--- a/root/etc/e-smith/templates/etc/yum.repos.d/NethServer.repo/10base
+++ b/root/etc/e-smith/templates/etc/yum.repos.d/NethServer.repo/10base
@@ -1,4 +1,8 @@
 {
+    # extra gpgkey's for AltArch
+    our $armhfp_gpgkey = ( -e '/etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-Arm32' ) ? "\n       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-Arm32" : "";
+    our $aarch64_gpgkey = ( -e '/etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7-aarch64' ) ? "\n       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7-aarch64" : "";
+
     our $communityEnabled = $subscription{'SystemId'} ? '0' : '1';
     '';
 }
@@ -38,7 +42,7 @@ mirrorlist=http://mirrorlist.nethserver.org/?release=$releasever&repo=ce-base&ar
 #baseurl=http://mirror.centos.org/centos/$nsrelease/os/$basearch/
 gpgcheck=1
 repo_gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 {$armhfp_gpgkey} {$aarch64_gpgkey}
 enabled={$communityEnabled}
 
 [ce-updates]
@@ -47,7 +51,7 @@ mirrorlist=http://mirrorlist.nethserver.org/?release=$releasever&repo=ce-updates
 #baseurl=http://mirror.centos.org/centos/$nsrelease/updates/$basearch/
 gpgcheck=1
 repo_gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 {$armhfp_gpgkey} {$aarch64_gpgkey}
 enabled={$communityEnabled}
 
 [ce-extras]
@@ -56,7 +60,7 @@ mirrorlist=http://mirrorlist.nethserver.org/?release=$releasever&repo=ce-extras&
 #baseurl=http://mirror.centos.org/centos/$nsrelease/extras/$basearch/
 gpgcheck=1
 repo_gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 {$armhfp_gpgkey} {$aarch64_gpgkey}
 enabled={$communityEnabled}
 
 [ce-sclo-sclo]

--- a/root/etc/e-smith/templates/etc/yum.repos.d/NethServer.repo/10base
+++ b/root/etc/e-smith/templates/etc/yum.repos.d/NethServer.repo/10base
@@ -1,7 +1,16 @@
 {
-    # extra gpgkey's for AltArch
-    our $armhfp_gpgkey = ( -e '/etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-Arm32' ) ? "\n       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-Arm32" : "";
-    our $aarch64_gpgkey = ( -e '/etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7-aarch64' ) ? "\n       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7-aarch64" : "";
+    # extra gpgkey's and conditional repo_gpgcheck for AltArchs
+    our $repo_gpgcheck = '1';
+    our $armhfp_gpgkey = "";
+    our $aarch64_gpgkey = "";
+        if ( -e '/etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-Arm32' ) {
+       $armhfp_gpgkey =  "\n       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-Arm32";
+       $repo_gpgcheck = '0';
+    }
+    if ( -e '/etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7-aarch64' ) {
+       $aarch64_gpgkey = "\n       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7-aarch64";
+       $repo_gpgcheck = '0';
+    }
 
     our $communityEnabled = $subscription{'SystemId'} ? '0' : '1';
     '';
@@ -41,7 +50,7 @@ name=CE-Base-$nsrelease
 mirrorlist=http://mirrorlist.nethserver.org/?release=$releasever&repo=ce-base&arch=$basearch&nsrelease=$nsrelease
 #baseurl=http://mirror.centos.org/centos/$nsrelease/os/$basearch/
 gpgcheck=1
-repo_gpgcheck=1
+repo_gpgcheck={$repo_gpgcheck}
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 {$armhfp_gpgkey} {$aarch64_gpgkey}
 enabled={$communityEnabled}
 
@@ -50,7 +59,7 @@ name=CE-Updates-$nsrelease
 mirrorlist=http://mirrorlist.nethserver.org/?release=$releasever&repo=ce-updates&arch=$basearch&nsrelease=$nsrelease
 #baseurl=http://mirror.centos.org/centos/$nsrelease/updates/$basearch/
 gpgcheck=1
-repo_gpgcheck=1
+repo_gpgcheck={$repo_gpgcheck}
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 {$armhfp_gpgkey} {$aarch64_gpgkey}
 enabled={$communityEnabled}
 
@@ -59,7 +68,7 @@ name=CE-Extras-$nsrelease
 mirrorlist=http://mirrorlist.nethserver.org/?release=$releasever&repo=ce-extras&arch=$basearch&nsrelease=$nsrelease
 #baseurl=http://mirror.centos.org/centos/$nsrelease/extras/$basearch/
 gpgcheck=1
-repo_gpgcheck=1
+repo_gpgcheck={$repo_gpgcheck}
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 {$armhfp_gpgkey} {$aarch64_gpgkey}
 enabled={$communityEnabled}
 

--- a/root/etc/e-smith/templates/etc/yum.repos.d/NethServer.repo/10base
+++ b/root/etc/e-smith/templates/etc/yum.repos.d/NethServer.repo/10base
@@ -41,6 +41,7 @@ name=CE-Base-$nsrelease
 mirrorlist=http://mirrorlist.nethserver.org/?release=$releasever&repo=ce-base&arch=$basearch&nsrelease=$nsrelease
 #baseurl=http://mirror.centos.org/centos/$nsrelease/os/$basearch/
 gpgcheck=1
+repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 {$armhfp_gpgkey} {$aarch64_gpgkey}
 enabled={$communityEnabled}
 
@@ -49,6 +50,7 @@ name=CE-Updates-$nsrelease
 mirrorlist=http://mirrorlist.nethserver.org/?release=$releasever&repo=ce-updates&arch=$basearch&nsrelease=$nsrelease
 #baseurl=http://mirror.centos.org/centos/$nsrelease/updates/$basearch/
 gpgcheck=1
+repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 {$armhfp_gpgkey} {$aarch64_gpgkey}
 enabled={$communityEnabled}
 
@@ -57,6 +59,7 @@ name=CE-Extras-$nsrelease
 mirrorlist=http://mirrorlist.nethserver.org/?release=$releasever&repo=ce-extras&arch=$basearch&nsrelease=$nsrelease
 #baseurl=http://mirror.centos.org/centos/$nsrelease/extras/$basearch/
 gpgcheck=1
+repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 {$armhfp_gpgkey} {$aarch64_gpgkey}
 enabled={$communityEnabled}
 


### PR DESCRIPTION
NethServer/arm-dev#31

`yum makecache` also fails on armhfp if repo_gpgcheck's are enabled;
Hence iv removed those too. Note : in (x86_64) `Centos-Base.repo` they are also not enabled (at least on my cenots 7.7 system)