### PR TITLE
Bump NS 7.9.2009 release version

### DIFF
--- a/nethserver-release.spec
+++ b/nethserver-release.spec
@@ -1,4 +1,4 @@
-%define distroversion 7.8.2003
+%define distroversion 7.9.2009
 %define distrorelease final
 
 Summary: NethServer YUM repo configuration


### PR DESCRIPTION
The new nethserver-release version has to be uploaded to 7.9.2009 updates. It is required by

- Install on CentOS use case
- Server Manager dashboard, to show the correct system version number

https://github.com/NethServer/dev/issues/6330